### PR TITLE
Update Readme to 3.8.3 and Reformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
 3. `cd SPT.Docker`
 4. Build the server for your requested version, (you can change the `--build-arg` to the full commit hash from the [SPT-Aki/Server Gitea Page](https://dev.sp-tarkov.com/SPT-AKI/Server))
 
-   > [!CAUTION]
-   > Windows doesn't handle the \\, use the oneliner!
+> [!CAUTION]
+> Windows doesn't handle the \\, use the oneliner!
 
    Equivalent to release SPT-Aki-3.8.3-01783e2 (0.14.1.2.29197):
    ```bash

--- a/README.md
+++ b/README.md
@@ -18,9 +18,6 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
 3. `cd SPT.Docker`
 4. Build the server for your requested version, (you can change the `--build-arg` to the full commit hash from the [SPT-Aki/Server Gitea Page](https://dev.sp-tarkov.com/SPT-AKI/Server))
 
-> [!CAUTION]
-> Windows doesn't handle the \\, use the oneliner!
-
    Equivalent to release SPT-Aki-3.8.3-01783e2 (0.14.1.2.29197):
    ```bash
    docker build \
@@ -47,26 +44,28 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
    ```bash
    docker build --no-cache --build-arg SPT=3951e29a340e917d158ec061ee671c4ae0f9c8ec --label SPTAki -t sptaki .
    ```
+> [!CAUTION]
+> Windows doesn't handle the \\, use the oneliner!
 
-
-7. Run the image once:
+5. Run the image once:
    ```bash
    docker run --pull=never -v $PWD/server:/opt/server -p 6969:6969 -p 6970:6970 -p 6971:6971 -p 6972:6972 -it --name sptaki sptaki
    ```
-   > [!IMPORTANT]
-   > If you don't set the -v (volume), you won't be able to do a required step!
-
+   
+   - ⚠️ If you don't set the -v (volume), you won't be able to do a required step!
+     
    - On **Linux** you can include `--user $(id -u):$(id -g)`, this way, file ownership will be set to the user who started the container.
+     
    ```bash
    docker run --pull=never --user $(id -u):$(id -g) -v $PWD/server:/opt/server -p 6969:6969 -p 6970:6970 -it --name sptaki sptaki
    ```
 
-8. Go to your `./server` directory, delete `delete_me`, and optionally install additional mods, make config changes, etc.
+6. Go to your `./server` directory, delete `delete_me`, and optionally install additional mods, make config changes, etc.
     > Using `-p6969:6969`, you expose the port to `0.0.0.0` (meaning: open for LAN, localhost, VPN address, etc).
     > 
     > You can specify `-p 192.168.12.34:6969:6969` for each port if you don't want the ports to listen on all interfaces. 
    
-9. Start your server (and enable auto restart):
+7. Start your server (and enable auto restart):
     ```bash
    docker start sptaki
    docker update --restart unless-stopped sptaki

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
 3. `cd SPT.Docker`
 4. Build the server for your requested version, (you can change the `--build-arg` to the full commit hash from the Aki server Gitea page)
 
+> [!CAUTION]
+> Windows doesn't handle the \\, use the oneliner!
+
    Equivalent to release SPT-Aki-3.8.3-01783e2 (0.14.1.2.29197):
    ```bash
    docker build \
@@ -44,8 +47,6 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
    ```bash
    docker build --no-cache --build-arg SPT=3951e29a340e917d158ec061ee671c4ae0f9c8ec --label SPTAki -t sptaki .
    ```
-   
-   > Windows doesn't handle the \\, use the oneliner!
 
 
 7. Run the image once:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
 1. Install [DOCKER](https://docs.docker.com/engine/install/)
 2. `git clone https://github.com/umbraprior/SPT.Docker`
 3. `cd SPT.Docker`
-4. Build the server for your requested version, (you can change the `--build-arg` to the full commit hash from the Aki server Gitea page)
+4. Build the server for your requested version, (you can change the `--build-arg` to the full commit hash from the [SPT-Aki/Server Gitea Page](https://dev.sp-tarkov.com/SPT-AKI/Server))
 
 > [!CAUTION]
 > Windows doesn't handle the \\, use the oneliner!
@@ -53,7 +53,8 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
    ```bash
    docker run --pull=never -v $PWD/server:/opt/server -p 6969:6969 -p 6970:6970 -p 6971:6971 -p 6972:6972 -it --name sptaki sptaki
    ```
-   - ⚠️ If you don't set the -v (volume), you won't be able to do a required step!
+   > [!IMPORTANT]
+   > If you don't set the -v (volume), you won't be able to do a required step!
 
    - On **Linux** you can include `--user $(id -u):$(id -g)`, this way, file ownership will be set to the user who started the container.
    ```bash
@@ -73,4 +74,7 @@ docker update --restart unless-stopped sptaki
 8. ... wait a few seconds, then you can connect to `http://YOUR_IP:6969`
 
 ## Bugs and Issues
+> [!NOTE]
+> Unraid seems to build the server in a separate, unlabeled image. This will use ~10G of Docker vDisk and will not be automatically removed. Remove the unlabeled image after first run.
+
 Let me know if there are any. Feel free to submit a PR.

--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
 3. `cd SPT.Docker`
 4. Build the server for your requested version, (you can change the `--build-arg` to the full commit hash from the Aki server Gitea page)
 
-   Equivalent to release SPT-Aki-3.8.1-e8e317 (0.14.1.2.29197):
+   Equivalent to release SPT-Aki-3.8.3-01783e2 (0.14.1.2.29197):
    ```bash
    docker build \
       --no-cache \
-      --build-arg SPT=79a5d32cb276e18a5b4405e1f7823cda4fe8e317 \
+      --build-arg SPT=645adcfd49dc2889ec6bf320730523ddb5f6821a \
       --label SPTAki \
       -t sptaki .
    ```
    Same, but in one line:
    ```bash
-   docker build --no-cache --build-arg SPT=79a5d32cb276e18a5b4405e1f7823cda4fe8e317 --label SPTAki -t sptaki .
+   docker build --no-cache --build-arg SPT=645adcfd49dc2889ec6bf320730523ddb5f6821a --label SPTAki -t sptaki .
    ```
 
  
@@ -45,7 +45,7 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
    docker build --no-cache --build-arg SPT=3951e29a340e917d158ec061ee671c4ae0f9c8ec --label SPTAki -t sptaki .
    ```
    
-   > Windows dont handle the \\, use the oneliner!
+   > Windows doesn't handle the \\, use the oneliner!
 
 
 7. Run the image once:

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
    ```
    
    - ⚠️ If you don't set the -v (volume), you won't be able to do a required step!
-     
+   
    - On **Linux** you can include `--user $(id -u):$(id -g)`, this way, file ownership will be set to the user who started the container.
-     
+   
    ```bash
    docker run --pull=never --user $(id -u):$(id -g) -v $PWD/server:/opt/server -p 6969:6969 -p 6970:6970 -it --name sptaki sptaki
    ```

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
 3. `cd SPT.Docker`
 4. Build the server for your requested version, (you can change the `--build-arg` to the full commit hash from the [SPT-Aki/Server Gitea Page](https://dev.sp-tarkov.com/SPT-AKI/Server))
 
-> [!CAUTION]
-> Windows doesn't handle the \\, use the oneliner!
+   > [!CAUTION]
+   > Windows doesn't handle the \\, use the oneliner!
 
    Equivalent to release SPT-Aki-3.8.3-01783e2 (0.14.1.2.29197):
    ```bash
@@ -67,10 +67,10 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
     > You can specify `-p 192.168.12.34:6969:6969` for each port if you don't want the ports to listen on all interfaces. 
    
 9. Start your server (and enable auto restart):
- ```bash
-docker start sptaki
-docker update --restart unless-stopped sptaki
-```
+    ```bash
+   docker start sptaki
+   docker update --restart unless-stopped sptaki
+   ```
 8. ... wait a few seconds, then you can connect to `http://YOUR_IP:6969`
 
 ## Bugs and Issues

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
    ```
    
    - ⚠️ If you don't set the -v (volume), you won't be able to do a required step!
-   
+
    - On **Linux** you can include `--user $(id -u):$(id -g)`, this way, file ownership will be set to the user who started the container.
-   
+
    ```bash
    docker run --pull=never --user $(id -u):$(id -g) -v $PWD/server:/opt/server -p 6969:6969 -p 6970:6970 -it --name sptaki sptaki
    ```

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
    docker start sptaki
    docker update --restart unless-stopped sptaki
    ```
-8. ... wait a few seconds, then you can connect to `http://YOUR_IP:6969`
+8. ... wait a few seconds, then you can connect to `http://YOUR_IP:6969` in Aki.Launcher
 
 ## Bugs and Issues
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This fork simply removes the SIT(stayintarkov) requirements to make a generic SP
     > You can specify `-p 192.168.12.34:6969:6969` for each port if you don't want the ports to listen on all interfaces. 
    
 7. Start your server (and enable auto restart):
-    ```bash
+   ```bash
    docker start sptaki
    docker update --restart unless-stopped sptaki
    ```


### PR DESCRIPTION
I have updated the 3.8.1 build args to show the hash for 3.8.3 release.
I have also done a bit of reformatting to fix numbering, some indentations, and add the markdown caution box.

I also added a small info note at the bottom about Unraid's image usage.