### PR TITLE
git-lfs: fetch less file to speed up

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone --branch $SPT_BRANCH https://dev.sp-tarkov.com/SPT/Server.git srv 
 ## Check out and git-lfs (specific commit --build-arg SPT=xxxx)
 WORKDIR /opt/srv/project 
 RUN git checkout $SPT || true
-RUN git-lfs fetch --all && git-lfs pull
+RUN git-lfs fetch && git-lfs pull
 
 ## Install npm dependencies and run build
 RUN \. $HOME/.nvm/nvm.sh && npm install && npm run build:release -- --arch=$([ "$(uname -m)" = "aarch64" ] && echo arm64 || echo x64) --platform=linux


### PR DESCRIPTION
now only fetch ~700MB git-lfs file, much faster than before and save disk space.Already tested on my vps, it works fine as before.
```bash
root@sin1:~/SPT.Docker# docker build --no-cache --build-arg SPT=d0d10ac15cdd0f6aa41682c0575ca6ba410c2551 --label SPT -t spt .
[+] Building 410.9s (23/23) FINISHED                                                                                                                                          docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                    0.1s
 => => transferring dockerfile: 1.39kB                                                                                                                                                  0.0s
 => [internal] load metadata for docker.io/library/ubuntu:latest                                                                                                                        2.0s
 => [internal] load .dockerignore                                                                                                                                                       0.0s
 => => transferring context: 2B                                                                                                                                                         0.0s
 => [builder  1/13] FROM docker.io/library/ubuntu:latest@sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30                                                        0.0s
 => [internal] load build context                                                                                                                                                       0.0s
 => => transferring context: 886B                                                                                                                                                       0.0s
 => CACHED [builder  2/13] WORKDIR /opt                                                                                                                                                 0.0s
 => [builder  3/13] RUN apt update && apt install -yq git git-lfs curl                                                                                                                 32.9s
 => [stage-1 3/7] RUN apt update && apt upgrade -yq && apt install -yq dos2unix                                                                                                        24.2s
 => [builder  4/13] RUN git clone https://github.com/nvm-sh/nvm.git $HOME/.nvm || true                                                                                                  1.5s 
 => [builder  5/13] RUN . $HOME/.nvm/nvm.sh && nvm install 20.11.1                                                                                                                     15.0s 
 => [builder  6/13] RUN git clone --branch master https://dev.sp-tarkov.com/SPT/Server.git srv || true                                                                                 70.5s 
 => [builder  7/13] WORKDIR /opt/srv/project                                                                                                                                            0.0s 
 => [builder  8/13] RUN git checkout d0d10ac15cdd0f6aa41682c0575ca6ba410c2551 || true                                                                                                   0.6s 
 => [builder  9/13] RUN git-lfs fetch && git-lfs pull                                                                                                                                   0.4s 
 => [builder 10/13] RUN . $HOME/.nvm/nvm.sh && npm install && npm run build:release -- --arch=$([ "$(uname -m)" = "aarch64" ] && echo arm64 || echo x64) --platform=linux             242.5s 
 => [builder 11/13] RUN mv build/ /opt/server/                                                                                                                                          9.1s 
 => [builder 12/13] WORKDIR /opt                                                                                                                                                        0.1s 
 => [builder 13/13] RUN rm -rf srv/                                                                                                                                                     5.3s 
 => [stage-1 4/7] COPY --from=builder /opt/server /opt/srv                                                                                                                              8.9s 
 => [stage-1 5/7] COPY bullet.sh /opt/bullet.sh                                                                                                                                         0.0s 
 => [stage-1 6/7] RUN dos2unix /opt/bullet.sh                                                                                                                                           0.6s 
 => [stage-1 7/7] RUN chmod o+rwx /opt /opt/srv /opt/srv/* -R                                                                                                                           9.4s
 => exporting to image                                                                                                                                                                  8.0s
 => => exporting layers                                                                                                                                                                 7.9s
 => => writing image sha256:c893fc32b69e26b342346c4d98f0932bc5929ba793a1d19145cf0e653f45aee2                                                                                            0.0s
 => => naming to docker.io/library/spt                                                                                                                                                  0.0s

 1 warning found (use --debug to expand):
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 48)
```